### PR TITLE
Changed global jQuery reference inside function to $.

### DIFF
--- a/jquery.hoverIntent.js
+++ b/jquery.hoverIntent.js
@@ -85,7 +85,7 @@
         // A private function for handling mouse 'hovering'
         var handleHover = function(e) {
             // copy objects to be passed into t (required for event object to be passed in IE)
-            var ev = jQuery.extend({},e);
+            var ev = $.extend({},e);
             var ob = this;
 
             // cancel hoverIntent timer if it exists


### PR DESCRIPTION
Global jQuery reference is passed in as $, but was still being referenced as jQuery internally. This breaks if you are running in no conflict mode.
