### PR TITLE
Closing over reference to jQuery

### DIFF
--- a/jquery.hoverIntent.js
+++ b/jquery.hoverIntent.js
@@ -85,7 +85,7 @@
         // A private function for handling mouse 'hovering'
         var handleHover = function(e) {
             // copy objects to be passed into t (required for event object to be passed in IE)
-            var ev = jQuery.extend({},e);
+            var ev = $.extend({},e);
             var ob = this;
 
             // cancel hoverIntent timer if it exists


### PR DESCRIPTION
jQuery may not be there whenever we call handleHover; which is what was happening in my case, so using the closure would guarantee that it is there.
