### PR TITLE
Remove odd U+FEFF character

### DIFF
--- a/jquery.hoverIntent.js
+++ b/jquery.hoverIntent.js
@@ -1,4 +1,4 @@
-﻿/*!
+/*!
  * hoverIntent r7 // 2013.03.11 // jQuery 1.9.1+
  * http://cherne.net/brian/resources/jquery.hoverIntent.html
  *


### PR DESCRIPTION
There was an odd [zero-width no-break space](https://en.wikipedia.org/wiki/Zero-width_no-break_space) character at the start of the file. These should never
be part of an actual file.

Follows-up b7a2d7f36ae2d5a30e02.
