### PR TITLE
updated jquery version dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "jquery": "1.9.1"
+    "jquery": ">=1.9.1"
   }
 }


### PR DESCRIPTION
works with 2.0 as well,
we can't integrate this plugin with bower ( we use jQuery >=2 )
