### PR TITLE
Make bower.json name match registry name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "jquery-hoverintent",
+  "name": "jquery-hoverIntent",
   "version": "1.8.1",
   "homepage": "http://cherne.net/brian/resources/jquery.hoverIntent.html",
   "repository": {


### PR DESCRIPTION
The name of this package in the Bower registry capitalizes the `i` in `hoverIntent`. Probably best to have these match.
