### PR TITLE
Allow older jQuery versions?

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "jquery": ">=1.9.1"
+    "jquery": ">=1.7.0"
   }
 }


### PR DESCRIPTION
Looking through the code, I didn't see any obvious things which would prevent hoverIntent from working with older versions of jQuery. And I have it successfully running on 1.7.

If you don't know of any problems, maybe we could merge this change so Bower can automatically resolve these older versions of jQuery?