### PR TITLE
Don't invoke `undefined`

### DIFF
--- a/jquery.hoverIntent.js
+++ b/jquery.hoverIntent.js
@@ -81,7 +81,7 @@
     // triggers given `out` function at configured `timeout` after a mouseleave and clears state
     var delay = function(ev,$el,s,out) {
         delete $el.data('hoverIntent')[s.id];
-        return out.apply($el[0],[ev]);
+        return out && out.apply($el[0],[ev]);
     };
 
     $.fn.hoverIntent = function(handlerIn,handlerOut,selector) {


### PR DESCRIPTION
From what I can tell, `handlerOut` could be `undefined`, so we should check for that before trying to invoke it