### PR TITLE
Reuse `over` handler if `out` is not given

### DIFF
--- a/jquery.hoverIntent.js
+++ b/jquery.hoverIntent.js
@@ -93,8 +93,11 @@
         // extend the default configuration and parse parameters
         var cfg = $.extend({}, _cfg);
         if ( $.isPlainObject(handlerIn) ) {
-            cfg = $.extend(cfg, handlerIn );
-        } else if ($.isFunction(handlerOut)) {
+            cfg = $.extend(cfg, handlerIn);
+            if ( !$.isFunction(cfg.out) ) {
+                cfg.out = cfg.over;
+            }
+        } else if ( $.isFunction(handlerOut) ) {
             cfg = $.extend(cfg, { over: handlerIn, out: handlerOut, selector: selector } );
         } else {
             cfg = $.extend(cfg, { over: handlerIn, out: handlerIn, selector: handlerOut } );


### PR DESCRIPTION
Fixes the bug where, if the plugin was initialized with a configuration
object, it wouldn't check whether the (optional) `out` function was
provided before attempting to use it. This resulted in an error.

In this case, it now reuses the (required) `over` function.

Closes briancherne/jquery-hoverIntent#42.