### PR TITLE
Add a semicolon to prevent errors when merging

### DIFF
--- a/jquery.hoverIntent.js
+++ b/jquery.hoverIntent.js
@@ -30,7 +30,7 @@
  * @author Brian Cherne <brian(at)cherne(dot)net>
  */
 
-(function(factory) {
+;(function(factory) {
     'use strict';
     if (typeof define === 'function' && define.amd) {
         define(['jquery'], factory);


### PR DESCRIPTION
When this plugin get's merged with other JS files there wil be an error if the preceding file doesn't use a semicolon in the end.