### PR TITLE
Fix race condition when `delay()` is called after a timeout

### DIFF
--- a/jquery.hoverIntent.js
+++ b/jquery.hoverIntent.js
@@ -85,7 +85,10 @@
 
     // triggers given `out` function at configured `timeout` after a mouseleave and clears state
     var delay = function(ev,$el,s,out) {
-        delete $el.data('hoverIntent')[s.id];
+        var data = $el.data('hoverIntent');
+        if (data) {
+            delete data[s.id];
+        }
         return out.apply($el[0],[ev]);
     };
 


### PR DESCRIPTION
When the mouse leaves an active element element, `delay()` is called [after a timeout][1]. If during that time the node is removed with `$(...).remove()`, the node's data will be cleared by jquery and accessing `$el.data('hoverIntent')[s.id]` in `delay()` will fail with an error like this:

> Uncaught TypeError: Cannot convert undefined or null to object

The error can be seen in the browser console when executing this fiddle: https://jsfiddle.net/t563wuve/

The solution is easy: Only delete the state if it's still there.

 [1]: https://github.com/briancherne/jquery-hoverIntent/blob/1e121b145c9722317318d0962da599b26226c479/jquery.hoverIntent.js#L154